### PR TITLE
chore(lint): enable godox linter as warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,6 @@ linters:
     - exhaustivestruct # deprecated
     - exhaustruct
     - gci
-    - godox
     - goerr113 # TODO: turn on and fix
     - golint # deprecated
     - gomoddirectives # TODO: remove when go-rpm is updated.
@@ -111,3 +110,10 @@ issues:
     - linters:
         - lll
       source: '^\s*//'
+
+severity:
+  default-severity: error
+  rules:
+    - linters:
+        - godox
+      severity: warning

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@ linters:
     - exhaustruct
     - exhaustruct_v5
     - goconst
-    - godox
     - gomodguard # deprecated
     - mnd
     - musttag
@@ -113,3 +112,10 @@ formatters:
         group-params: true
         clothe-returns: true
         balance-calls: true
+
+severity:
+  default: error
+  rules:
+    - linters:
+        - godox
+      severity: warning


### PR DESCRIPTION
Blocked by:
- https://github.com/golangci/golangci-lint/issues/1981