### PR TITLE
test(acceptance): only test against stable distro versions, run in parallel

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,7 +1,10 @@
 name: Acceptance Test
 
 on:
+  push:
+    branches: [master]
   pull_request:
+    branches: [master]
   workflow_dispatch:
 
 permissions:
@@ -48,7 +51,7 @@ jobs:
           fi
 
   test:
-    name: Test ${{ matrix.package }}
+    name: ${{ matrix.package }}
     if: needs.packages.outputs.packages != '[]'
     needs: packages
     runs-on: ubuntu-latest
@@ -65,7 +68,14 @@ jobs:
           go-version-file: go.mod
 
       - name: Run acceptance tests
-        run: go test -v -tags acceptance -run ^TestAcceptance$ ./${{ matrix.package }}
+        run: |
+          go test -v -tags acceptance -run ^TestAcceptance$ -coverprofile coverage.out -coverpkg=./... ./${{ matrix.package }}
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ${{ matrix.package }}
 
   acceptance:
     name: Acceptance Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - nonamedreturns
     - paralleltest
     - recvcheck
+    - tparallel
     - varnamelen
     - wrapcheck
     - wsl

--- a/integrations/apk/acceptance_test.go
+++ b/integrations/apk/acceptance_test.go
@@ -17,7 +17,7 @@ func TestAcceptance(t *testing.T) {
 		name  string
 		image string
 	}{
-		{"Alpine 3", "alpine:3"},
+		{"Alpine", "alpine:latest"},
 	}
 
 	tests := []struct {

--- a/integrations/yum/acceptance_test.go
+++ b/integrations/yum/acceptance_test.go
@@ -27,11 +27,9 @@ func TestAcceptance(t *testing.T) {
 		image string
 		pkg   string
 	}{
-		{"RHEL 9", "registry.access.redhat.com/ubi9/ubi:latest", "dnf"},
-		{"RHEL 8", "registry.access.redhat.com/ubi8/ubi:latest", "dnf"},
-		{"Fedora 39", "fedora:39", "dnf"},
-		{"Fedora 38", "fedora:38", "dnf"},
-		{"openSUSE Leap 15", "opensuse/leap:15", "zypper"},
+		{"RHEL 9", "redhat/ubi9:latest", "dnf"},
+		{"Fedora", "fedora:latest", "dnf"},
+		{"openSUSE", "opensuse/leap:latest", "zypper"},
 	}
 
 	tests := []struct {
@@ -44,6 +42,8 @@ func TestAcceptance(t *testing.T) {
 
 	for _, distro := range distros {
 		t.Run(distro.name, func(t *testing.T) {
+			t.Parallel()
+
 			dir := t.TempDir()
 			pgpKey, _ := pgp.NewPrivateKey("test", "test@example.com")
 			src, _ := source.New(source.Config{Path: "../../testdata"})

--- a/internal/emulator/option.go
+++ b/internal/emulator/option.go
@@ -1,0 +1,16 @@
+package emulator
+
+import "github.com/testcontainers/testcontainers-go"
+
+// Option allows configuring the container request.
+type Option func(*testcontainers.ContainerRequest)
+
+// WithEnv sets an environment variable for the container.
+func WithEnv(key, value string) Option {
+	return func(r *testcontainers.ContainerRequest) {
+		if r.Env == nil {
+			r.Env = map[string]string{}
+		}
+		r.Env[key] = value
+	}
+}


### PR DESCRIPTION
This pull request includes several changes to the acceptance tests and the container emulator configuration. The main improvements involve updating the test configurations, adding code coverage reporting, and enhancing the emulator's container setup.

### Updates to acceptance tests:

* [`.github/workflows/acceptance.yml`](diffhunk://#diff-20178bfee541d27c8c2296d927b63f9c6fec922b9ead4965f2e35958204baebbR4-R7): Added push and pull_request triggers for the master branch and included code coverage reporting with Codecov. [[1]](diffhunk://#diff-20178bfee541d27c8c2296d927b63f9c6fec922b9ead4965f2e35958204baebbR4-R7) [[2]](diffhunk://#diff-20178bfee541d27c8c2296d927b63f9c6fec922b9ead4965f2e35958204baebbL51-R54) [[3]](diffhunk://#diff-20178bfee541d27c8c2296d927b63f9c6fec922b9ead4965f2e35958204baebbL68-R78)
* [`integrations/apk/acceptance_test.go`](diffhunk://#diff-026764800d2e564f4a15b9002c280f0cde5854209c85d51b5f096208d3f00d0aL20-R20): Updated the test image to use the latest Alpine version.
* [`integrations/apt/acceptance_test.go`](diffhunk://#diff-dd3474d0cd90d81790612d36cf36cc64b12b641a242bce60072bec7b208de565L20-R21): Updated test images to use the latest Debian and Ubuntu versions, added parallel test execution, and simplified container setup. [[1]](diffhunk://#diff-dd3474d0cd90d81790612d36cf36cc64b12b641a242bce60072bec7b208de565L20-R21) [[2]](diffhunk://#diff-dd3474d0cd90d81790612d36cf36cc64b12b641a242bce60072bec7b208de565R34-R43)
* [`integrations/yum/acceptance_test.go`](diffhunk://#diff-a42b0fb2475794ec73e32274203238ec8c567ad0cbf94c2d2c721faecfa4a77fL30-R32): Updated test images to use the latest RHEL, Fedora, and openSUSE versions, and added parallel test execution. [[1]](diffhunk://#diff-a42b0fb2475794ec73e32274203238ec8c567ad0cbf94c2d2c721faecfa4a77fL30-R32) [[2]](diffhunk://#diff-a42b0fb2475794ec73e32274203238ec8c567ad0cbf94c2d2c721faecfa4a77fR45-R46)

### Enhancements to container emulator:

* [`internal/emulator/container.go`](diffhunk://#diff-4ce149dc63716054e1646dc0dc73b5446e4588a0e511191ded99bb4bce8bb9deL44-R53): Modified `Image` and `Build` functions to accept additional options for container configuration. [[1]](diffhunk://#diff-4ce149dc63716054e1646dc0dc73b5446e4588a0e511191ded99bb4bce8bb9deL44-R53) [[2]](diffhunk://#diff-4ce149dc63716054e1646dc0dc73b5446e4588a0e511191ded99bb4bce8bb9deL76-R83)
* [`internal/emulator/option.go`](diffhunk://#diff-77caa90016676c8655fe7bb68bdadaacb0ff0c285b88877f2839212376ba9081R1-R16): Introduced the `Option` type and `WithEnv` function to allow setting environment variables for containers.

### Linter configuration:

* [`.golangci.yml`](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R27): Remove the `tparallel` linter.