### PR TITLE
build(deps): bump github.com/cavaliergopher/rpm from 1.2.0 to 1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/kubri/kubri
 
 go 1.24
 
-// TODO: Remove when v1.3.0 is released:
-replace github.com/cavaliergopher/rpm v1.2.0 => github.com/cavaliergopher/rpm v0.0.0-20231126213118-b2e876bef7ce
-
 // TODO: Remove when the following PR is merged:
 // https://github.com/invopop/jsonschema/pull/126
 replace github.com/invopop/jsonschema v0.12.0 => github.com/abemedia/jsonschema v0.0.0-20240108235924-6da915f1869e
@@ -19,7 +16,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.1.6
 	github.com/ProtonMail/gopenpgp/v2 v2.8.3
 	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb
-	github.com/cavaliergopher/rpm v1.2.0
+	github.com/cavaliergopher/rpm v1.3.0
 	github.com/dlclark/regexp2 v1.11.5
 	github.com/docker/docker v28.0.4+incompatible
 	github.com/docker/go-connections v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/caarlos0/testfs v0.4.4 h1:3PHvzHi5Lt+g332CiShwS8ogTgS3HjrmzZxCm6JCDr8
 github.com/caarlos0/testfs v0.4.4/go.mod h1:bRN55zgG4XCUVVHZCeU+/Tz1Q6AxEJOEJTliBy+1DMk=
 github.com/cavaliergopher/cpio v1.0.1 h1:KQFSeKmZhv0cr+kawA3a0xTQCU4QxXF1vhU7P7av2KM=
 github.com/cavaliergopher/cpio v1.0.1/go.mod h1:pBdaqQjnvXxdS/6CvNDwIANIFSP0xRKI16PX4xejRQc=
-github.com/cavaliergopher/rpm v0.0.0-20231126213118-b2e876bef7ce h1:tJ6kCFTfEFyCloU7CJxNHUjlPFqy5XpKQovsKH3msoM=
-github.com/cavaliergopher/rpm v0.0.0-20231126213118-b2e876bef7ce/go.mod h1:vEumo1vvtrHM1Ov86f6+k8j7zNKOxQfHDCAIcR/36ZI=
+github.com/cavaliergopher/rpm v1.3.0 h1:UHX46sasX8MesUXXQ+UbkFLUX4eUWTlEcX8jcnRBIgI=
+github.com/cavaliergopher/rpm v1.3.0/go.mod h1:vEumo1vvtrHM1Ov86f6+k8j7zNKOxQfHDCAIcR/36ZI=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
* Updated the `github.com/cavaliergopher/rpm` dependency from version `v1.2.0` to `v1.3.0`.
* Removed the temporary replacement for `github.com/cavaliergopher/rpm` version `v1.2.0`.