### PR TITLE
feat(rsa): increase key size to 4096

### DIFF
--- a/pkg/crypto/rsa/rsa.go
+++ b/pkg/crypto/rsa/rsa.go
@@ -37,7 +37,7 @@ func Verify(key *PublicKey, data, sig []byte) bool {
 
 // NewPrivateKey returns a new private key.
 func NewPrivateKey() (*PrivateKey, error) {
-	return rsa.GenerateKey(rand.Reader, 2048)
+	return rsa.GenerateKey(rand.Reader, 4096)
 }
 
 // MarshalPrivateKey returns the PEM encoded private key.


### PR DESCRIPTION
This pull request includes a change to the `pkg/crypto/rsa/rsa.go` file to enhance the security of the RSA keys generated by the `NewPrivateKey` function.

Security improvement:

* [`pkg/crypto/rsa/rsa.go`](diffhunk://#diff-717a48780dbb976a8fba17da62685ab5a58cfc6a57f17e0516ba92718b0f5638L40-R40): Increased the key size from 2048 bits to 4096 bits in the `NewPrivateKey` function to provide stronger encryption.