### PR TITLE
ci: only run tests if Go files changed

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -3,8 +3,16 @@ name: Acceptance Test
 on:
   push:
     branches: [master]
+    paths:
+      - '**.go'
+      - go.mod
+      - go.sum
   pull_request:
     branches: [master]
+    paths:
+      - '**.go'
+      - go.mod
+      - go.sum
   workflow_dispatch:
 
 permissions:
@@ -33,7 +41,7 @@ jobs:
 
       - name: Find packages with changes
         id: packages
-        if: steps.deps.outputs.any_changed != 'true'
+        if: steps.deps.outputs.any_changed == 'false'
         uses: tj-actions/changed-files@v46
         with:
           files: integrations/**

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,7 @@ name: Benchmark
 on:
   pull_request:
     branches: [master]
+    paths: ['**.go']
 
 permissions:
   contents: read
@@ -26,17 +27,15 @@ jobs:
         id: packages
         uses: tj-actions/changed-files@v46
         with:
-          files: '**/*.go'
+          files: '**.go'
           dir_names: true
           json: true
 
       - name: Checkout repository
-        if: steps.packages.outputs.any_changed == 'true'
         uses: actions/checkout@v4
 
       - name: Filter packages with benchmarks
         id: set-matrix
-        if: steps.packages.outputs.any_changed == 'true'
         run: |
           PACKAGES=${{ steps.packages.outputs.all_changed_and_modified_files }}
           filtered=()

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,16 @@ name: CodeQL
 on:
   push:
     branches: [master]
+    paths:
+      - '**.go'
+      - go.mod
+      - go.sum
   pull_request:
     branches: [master]
+    paths:
+      - '**.go'
+      - go.mod
+      - go.sum
   schedule:
     - cron: '25 9 * * 4'
 

--- a/.github/workflows/skip.yml
+++ b/.github/workflows/skip.yml
@@ -1,0 +1,78 @@
+name: Skip
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - '**.go'
+      - go.mod
+      - go.sum
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - '**.go'
+      - go.mod
+      - go.sum
+
+jobs:
+  detect:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.detect.outputs.any_changed }}
+    steps:
+      - name: Checkout repository
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v4
+
+      - name: Detect Go file changes
+        id: detect
+        uses: tj-actions/changed-files@v46
+        with:
+          files: |
+            **.go
+            go.mod
+            go.sum
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.changed == 'false'
+    steps:
+      - name: Skip test
+        run: echo "No Go files changed, skipping test."
+      - name: Codecov empty upload
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          run_command: empty-upload
+          force: true
+          flags: skipped
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.changed == 'false'
+    steps:
+      - name: Skip lint
+        run: echo "No Go files changed, skipping lint."
+
+  acceptance:
+    name: Acceptance Test
+    runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.changed == 'false'
+    steps:
+      - name: Skip acceptance test
+        run: echo "No Go files changed, skipping acceptance test."
+
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.changed == 'false'
+    steps:
+      - name: Skip CodeQL Analysis
+        run: echo "No Go files changed, skipping CodeQL Analysis."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,14 +3,29 @@ name: Test
 on:
   push:
     branches: [master]
+    paths:
+      - '**.go'
+      - go.mod
+      - go.sum
   pull_request:
     branches: [master]
+    paths:
+      - '**.go'
+      - go.mod
+      - go.sum
   workflow_call:
     secrets:
       GH_TOKEN:
         required: true
       GITLAB_TOKEN:
         required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -43,6 +58,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit
 
   lint:
     name: Lint


### PR DESCRIPTION
- Only run unit test, linting, acceptance test codeql and benchmark workflows if Go files changed.
- Add `Skip` workflow to mark workflows as passed when there are no Go changes.
- Add permissions, concurrency and `unit` codecov flag to test workflow.
- Skip finding packages when running acceptance tests via `workflow_dispatch`.