### PR TITLE
fix(arch): include arch integration in build command

### DIFF
--- a/pkg/cmd/build.go
+++ b/pkg/cmd/build.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubri/kubri/integrations/apk"
 	"github.com/kubri/kubri/integrations/appinstaller"
 	"github.com/kubri/kubri/integrations/apt"
+	"github.com/kubri/kubri/integrations/arch"
 	"github.com/kubri/kubri/integrations/sparkle"
 	"github.com/kubri/kubri/integrations/yum"
 	"github.com/kubri/kubri/pkg/config"
@@ -38,6 +39,7 @@ func buildCmd() *cobra.Command {
 				{"APK", fn(apk.Build, p.Apk)},
 				{"App Installer", fn(appinstaller.Build, p.Appinstaller)},
 				{"APT", fn(apt.Build, p.Apt)},
+				{"Arch", fn(arch.Build, p.Arch)},
 				{"YUM", fn(yum.Build, p.Yum)},
 				{"Sparkle", fn(sparkle.Build, p.Sparkle)},
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Arch integration is now available in the build command. When configured, Arch packages will be published concurrently alongside other selected integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->